### PR TITLE
Remove deprecated fields from {File,Folder,Deleted}Metadata

### DIFF
--- a/src/Dropbox.elm
+++ b/src/Dropbox.elm
@@ -426,11 +426,9 @@ type alias DownloadResponse =
     , id : String
     , clientModified : Date
     , serverModified : Date
-    , rev : String
     , size : Int -- XXX: should be UInt64
     , pathLower : Maybe String
     , pathDisplay : Maybe String
-    , parentSharedFolderId : Maybe String
     , mediaInfo : Maybe MediaInfo
     , sharingInfo : Maybe FileSharingInfo
     , propertyGroups : Maybe (List PropertyGroup)
@@ -447,11 +445,9 @@ decodeDownloadResponse content =
         |> Pipeline.required "id" Json.Decode.string
         |> Pipeline.required "client_modified" Json.Decode.Extra.date
         |> Pipeline.required "server_modified" Json.Decode.Extra.date
-        |> Pipeline.required "rev" Json.Decode.string
         |> Pipeline.required "size" Json.Decode.int
         |> optional "path_lower" Json.Decode.string
         |> optional "path_display" Json.Decode.string
-        |> optional "parent_shared_folder_id" Json.Decode.string
         |> optional "media_info" decodeMediaInfo
         |> optional "sharing_info" decodeFileSharingInfo
         |> optional "property_groups" (Json.Decode.list decodePropertyGroup)
@@ -762,7 +758,6 @@ type alias FileMetadata =
     , size : Int -- XXX: should be UInt64
     , pathLower : Maybe String
     , pathDisplay : Maybe String
-    , parentSharedFolderId : Maybe String
     , mediaInfo : Maybe MediaInfo
     , sharingInfo : Maybe FileSharingInfo
     , propertyGroups : Maybe (List PropertyGroup)
@@ -778,8 +773,6 @@ type alias FolderMetadata =
     , id : String
     , pathLower : Maybe String
     , pathDisplay : Maybe String
-    , parentSharedFolderId : Maybe String
-    , sharedFolderId : Maybe String
     , sharingInfo : Maybe FileSharingInfo
     , propertyGroups : Maybe (List PropertyGroup)
     }
@@ -791,7 +784,6 @@ type alias DeletedMetadata =
     { name : String
     , pathLower : Maybe String
     , pathDisplay : Maybe String
-    , parentSharedFolderId : Maybe String
     }
 
 
@@ -814,7 +806,6 @@ decodeFileMetadata =
         |> Pipeline.required "size" Json.Decode.int
         |> optional "path_lower" Json.Decode.string
         |> optional "path_display" Json.Decode.string
-        |> optional "parent_shared_folder_id" Json.Decode.string
         |> optional "media_info" decodeMediaInfo
         |> optional "sharing_info" decodeFileSharingInfo
         |> optional "property_groups" (Json.Decode.list decodePropertyGroup)
@@ -829,8 +820,6 @@ decodeFolderMetadata =
         |> Pipeline.required "id" Json.Decode.string
         |> optional "path_lower" Json.Decode.string
         |> optional "path_display" Json.Decode.string
-        |> optional "parent_shared_folder_id" Json.Decode.string
-        |> optional "shared_folder_id" Json.Decode.string
         |> optional "sharing_info" decodeFileSharingInfo
         |> optional "property_groups" (Json.Decode.list decodePropertyGroup)
 
@@ -841,7 +830,6 @@ decodeDeletedMetadata =
         |> Pipeline.required "name" Json.Decode.string
         |> optional "path_lower" Json.Decode.string
         |> optional "path_display" Json.Decode.string
-        |> optional "parent_shared_folder_id" Json.Decode.string
 
 
 {-| See <https://www.dropbox.com/developers/documentation/http/documentation#files-upload>


### PR DESCRIPTION
The following fields are deprecated from the Dropbox API. This commit removes them — so that client code needn't deal with them when it is creating or copying records; so that client references to them don't prevent their removal in the future; and to avoid red herrings in the Elm API.

Although technically a breaking change, avh4/elm-dropbox#6 makes it unlikely that client code has successfully used `ListFolderResponse` and therefore run into this.

Note: git will probably require a manual merge when this is PR applied on top of avh4/elm-dropbox#6, because this commit patches lines that are adjacent (although not the same as) the lines in that PR. I could re-submit these as a single PR. 

https://www.dropbox.com/developers/documentation/http/documentation#files-download:
* `DownloadResponse.rev`
* `DownloadResponse.parentSharedFolderId`

https://www.dropbox.com/developers/documentation/http/documentation#files-list_folder:
* `FileMetadata.parentSharedFolderId`
* `FolderMetadata.parentSharedFolderId`
* `FolderMetadata.sharedFolderId`
* `DeletedMetadata.parentSharedFolderId`